### PR TITLE
Restart Nautilus as the user running the script, instead of sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ restart_nautilus() {
     read -p "Restart Nautilus(Files)? [Y/n]" ans
 
     if [[ $ans == 'y' || $ans == 'Y' || $ans == '' ]]; then
-        nautilus -q
+        sudo -u $SUDO_USER nautilus -q
     fi
 }
 


### PR DESCRIPTION
The ```install.sh``` script displays warnings and errors if you run ```nautilus -q``` as ```sudo```, along with the rest of the script.

This fixes it by running this command as the user who is running the script with ```sudo```, using the ```$SUDO_USER``` variable, as described in ```man sudo```.